### PR TITLE
Make built-in CallSite functions source map aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,11 @@ someModule.doAsyncThing(function (err) {
 function printCallsites(err, callsites) {
   console.log('Error: %s', err.message)
   callsites.forEach(function (callsite) {
-    // sourceMap property is only available it a sourcemap can be resolved
-    var resolver = callsite.sourceMap || callsite
     console.log(
       '  in %s:%s:%s',
-      resolver.getFileName(),
-      resolver.getLineNumber(),
-      resolver.getColumnNumber()
+      callsite.getFileName(),
+      callsite.getLineNumber(),
+      callsite.getColumnNumber()
     )
   })
 }
@@ -59,7 +57,7 @@ function printCallsites(err, callsites) {
 * Source files are traversed, looking for references to a source map (`//# sourceMappingURL=some.js.map`)
 * The source map is read from filesystem (or parsed from base64 in the case of inline source maps)
 * A source map consumer is created using the [source-map](https://www.npmjs.com/package/source-map) module and cached in-memory
-* Each callsite with a valid source map is assigned a `sourceMap` property containing the following functions:
+* The following functions for each callsite are modified to return the information from the source map if available:
   - `getFileName()`
   - `getLineNumber()`
   - `getColumnNumber()`
@@ -67,7 +65,7 @@ function printCallsites(err, callsites) {
 
 ## Notes
 
-* Errors while reading the sourcemap is currently supressed. The `sourceMap` property will simply not be assigned in the case of errors. To debug why a sourcemap can't be resolved, you may pass `DEBUG=sourcemap-decorate-callsites` to your Node application, which will print debug info while resolving.
+* Errors while reading the sourcemap is currently supressed. The functions will simply not be modified in the case of errors. To debug why a sourcemap can't be resolved, you may pass `DEBUG=sourcemap-decorate-callsites` to your Node application, which will print debug info while resolving.
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,43 +143,50 @@ function decodeInlineMap (data) {
 }
 
 function extendCallsite (callsite, consumer, filename) {
-  callsite.sourceMap = getCallsiteResolver(callsite, consumer, filename)
-  return callsite
-}
-
-function getCallsiteResolver (callsite, consumer, filename) {
+  var getLineNumber = callsite.getLineNumber
+  var getColumnNumber = callsite.getColumnNumber
+  var getFileName = callsite.getFileName
   var position = null
 
   function getPosition () {
     if (!position) {
       position = consumer.originalPositionFor({
-        line: callsite.getLineNumber(),
-        column: callsite.getColumnNumber()
+        line: getLineNumber.call(callsite),
+        column: getColumnNumber.call(callsite)
       })
     }
 
     return position
   }
 
-  return {
-    getLineNumber: function () {
-      return getPosition().line || callsite.getLineNumber()
-    },
+  Object.defineProperties(callsite, {
+    getFileName: {
+      writable: false,
+      value: function () {
+        var source = getPosition().source
+        if (!source) {
+          return getFileName.call(callsite)
+        }
 
-    getColumnNumber: function () {
-      return getPosition().column || callsite.getLineNumber()
-    },
-
-    getFileName: function () {
-      var source = getPosition().source
-      if (!source) {
-        return callsite.getFileName()
+        var srcDir = path.dirname(filename)
+        return path.resolve(path.join(srcDir, source))
       }
-
-      var srcDir = path.dirname(filename)
-      return path.resolve(path.join(srcDir, source))
+    },
+    getLineNumber: {
+      writable: false,
+      value: function () {
+        return getPosition().line || getLineNumber.call(callsite)
+      }
+    },
+    getColumnNumber: {
+      writable: false,
+      value: function () {
+        return getPosition().column || getColumnNumber.call(callsite)
+      }
     }
-  }
+  })
+
+  return callsite
 }
 
 module.exports = function (callsites, cb) {

--- a/test/test.js
+++ b/test/test.js
@@ -124,40 +124,26 @@ test('files that has invalid inline sourcemaps silently falls back (async)', fun
   })
 })
 
-function extract (sourceMap) {
-  return {
-    fileName: sourceMap.getFileName(),
-    lineNumber: sourceMap.getLineNumber(),
-    columnNumber: sourceMap.getColumnNumber()
-  }
-}
-
 function assertFixtureCallsites (t, decorated) {
   var firstFrame = decorated[0]
-  var sourceMap = firstFrame.sourceMap
-  t.ok(sourceMap, 'has sourcemap')
-  t.equal(sourceMap.getFileName(), path.join(FIXTURES_DIR, 'src', 'util', 'generateError.js'), 'filename is mapped location')
-  t.equal(sourceMap.getLineNumber(), 1, 'line number is mapped location')
-  t.equal(sourceMap.getColumnNumber(), 73, 'column number is mapped location')
+  t.equal(firstFrame.getFileName(), path.join(FIXTURES_DIR, 'src', 'util', 'generateError.js'), 'filename is mapped location')
+  t.equal(firstFrame.getLineNumber(), 1, 'line number is mapped location')
+  t.equal(firstFrame.getColumnNumber(), 73, 'column number is mapped location')
 
   var secondFrame = decorated[1]
-  t.notOk(secondFrame.sourceMap, 'non-module code should not populate sourcemap')
+  t.equal(secondFrame.getFileName(), __filename, 'non-mapped code should still work')
   t.end()
 }
 
 function assertDeepCallsites (t, decorated) {
-  t.deepEqual(extract(decorated[0].sourceMap), {
-    fileName: path.join(FIXTURES_DIR, 'src', 'util', 'generateError.js'),
-    lineNumber: 1,
-    columnNumber: 73
-  }, 'callsite #0')
+  t.equal(decorated[0].getFileName(), path.join(FIXTURES_DIR, 'src', 'util', 'generateError.js'), 'filename is mapped location')
+  t.equal(decorated[0].getLineNumber(), 1, 'line number is mapped location')
+  t.equal(decorated[0].getColumnNumber(), 73, 'column number is mapped location')
 
   for (var i = 1; i < 10; i++) {
-    t.deepEqual(extract(decorated[i].sourceMap), {
-      fileName: path.join(FIXTURES_DIR, 'src', 'util', 'callAtDepth.js'),
-      lineNumber: i === 1 ? 6 : 3,
-      columnNumber: i === 1 ? 9 : 11
-    }, 'callsite #' + i)
+    t.equal(decorated[i].getFileName(), path.join(FIXTURES_DIR, 'src', 'util', 'callAtDepth.js'), 'getFileName for callsite #' + 1)
+    t.equal(decorated[i].getLineNumber(), i === 1 ? 6 : 3, 'getLineNumber for callsite #' + 1)
+    t.equal(decorated[i].getColumnNumber(), i === 1 ? 9 : 11, 'getColumnNumber for callsite #' + 1)
   }
   t.end()
 }


### PR DESCRIPTION
As a follow up to https://github.com/watson/stackman/pull/4#issuecomment-290058651, here's the minimum changes needed to support the proposed new v2 stackman API.

I doesn't do away with the sync part of the API, it only changes how each CallSite is modified:

Instead of adding a custom `sourceMap` property to the CallSite, it simply overwrites the 3 functions `getFileName`, `getLineNumber`, and `getColumnNumber` with source map aware versions of each function.

The means that the CallSite can be used normally without the recipient knowing anything about if a source map is used or not.